### PR TITLE
Avoid extra allocation.

### DIFF
--- a/lib/src/bindings/types.dart
+++ b/lib/src/bindings/types.dart
@@ -22,7 +22,7 @@ class GeoCoordNative extends Struct<GeoCoordNative> {
   double lon;
 
   static GeoCoordNative allocate({int count = 1}) {
-    return Pointer<GeoCoordNative>.allocate(count: count * sizeOf<GeoCoordNative>()).load();
+    return Pointer<GeoCoordNative>.allocate(count: count).load();
   }
 
   // Please ensure to [free] the memory manually!


### PR DESCRIPTION
The size of the struct is already factored into the total allocation size of `Pointer.allocate`.